### PR TITLE
fix(status): use buffer git root with Telescope

### DIFF
--- a/lua/astroui/status/component.lua
+++ b/lua/astroui/status/component.lua
@@ -188,7 +188,14 @@ function M.git_branch(opts)
       name = "heirline_branch",
       callback = function()
         if is_available "telescope.nvim" then
-          vim.defer_fn(function() require("telescope.builtin").git_branches() end, 100)
+          vim.defer_fn(
+            function()
+              require("telescope.builtin").git_branches {
+                use_file_path = true,
+              }
+            end,
+            100
+          )
         end
       end,
     },
@@ -212,7 +219,14 @@ function M.git_diff(opts)
       name = "heirline_git",
       callback = function()
         if is_available "telescope.nvim" then
-          vim.defer_fn(function() require("telescope.builtin").git_status() end, 100)
+          vim.defer_fn(
+            function()
+              require("telescope.builtin").git_status {
+                use_file_path = true,
+              }
+            end,
+            100
+          )
         end
       end,
     },


### PR DESCRIPTION
<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below
Closes #<Issue # here>
-->

## 📑 Description

Git on_click event(s) will return an error if Telescope is unable to ascertain git root directory (e.g., if buffer was opened through jump list). Telescope's git picker can use 'use_file_path' to prevent that.

Before:
![image](https://github.com/AstroNvim/astroui/assets/91024200/1d7df777-e787-45dd-9dad-6c19216aaca1)

After:
![Screenshot from 2023-10-28 17-13-37](https://github.com/AstroNvim/astroui/assets/91024200/50df7d83-6bbe-41c2-85fa-ce4c1ee37eed)
