### PR TITLE
fix(status): inconsistent padding for `file_read_only` and `file_modified` components

### DIFF
--- a/lua/astroui/status/component.lua
+++ b/lua/astroui/status/component.lua
@@ -41,7 +41,7 @@ function M.file_info(opts)
     filename = false,
     filetype = {},
     file_modified = false,
-    file_read_only = { padding = { left = 1, right = 1 }, condition = condition.is_file },
+    file_read_only = { padding = { left = 1 }, condition = condition.is_file },
     surround = { separator = "left", color = "file_info_bg", condition = condition.has_filetype },
     hl = hl.get_attributes "file_info",
   }, opts)
@@ -68,7 +68,7 @@ function M.tabline_file_info(opts)
     },
     filename = {},
     filetype = false,
-    file_modified = { padding = { left = 1, right = 1 }, condition = condition.is_file },
+    file_modified = { padding = { left = 1 }, condition = condition.is_file },
     unique_path = {
       hl = function(self) return hl.get_attributes(self.tab_type .. "_path") end,
     },

--- a/lua/astroui/status/component.lua
+++ b/lua/astroui/status/component.lua
@@ -40,7 +40,7 @@ function M.file_info(opts)
     file_icon = { hl = hl.file_icon "statusline", padding = { left = 1, right = 1 }, condition = condition.is_file },
     filename = false,
     filetype = {},
-    file_modified = false,
+    file_modified = { padding = { left = 1 }, condition = condition.is_file },
     file_read_only = { padding = { left = 1 }, condition = condition.is_file },
     surround = { separator = "left", color = "file_info_bg", condition = condition.has_filetype },
     hl = hl.get_attributes "file_info",
@@ -68,7 +68,7 @@ function M.tabline_file_info(opts)
     },
     filename = {},
     filetype = false,
-    file_modified = { padding = { left = 1 }, condition = condition.is_file },
+    file_modified = {},
     unique_path = {
       hl = function(self) return hl.get_attributes(self.tab_type .. "_path") end,
     },


### PR DESCRIPTION
<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below
Closes #<Issue # here>
-->

## 📑 Description

<!-- Add a brief description of the pr -->

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->
From v3 to v4, I've noticed that an extra right padding was added to the `file_read_only` and `file_modified` components. While minor, this adds double spacing between the two when a file has both been modified and is read only, which feels a bit inconsistent.

## ℹ Additional Information

<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
Before:
<img width="994" alt="image" src="https://github.com/AstroNvim/astroui/assets/56745535/bb8b0a01-1ea5-4ed7-b4d1-c89e6aa4262b">

After:
<img width="990" alt="image" src="https://github.com/AstroNvim/astroui/assets/56745535/0653b0d0-c373-4ee6-9332-492870624bd1">