### PR TITLE
feat(status): add a component to display sidebar titles

### DIFF
--- a/lua/astroui/config.lua
+++ b/lua/astroui/config.lua
@@ -73,6 +73,16 @@
 ---}
 ---```
 ---@field icon_highlights AstroUIIconHighlights?
+---Configure the titles displayed on the bufferline for sidebars of different filetypes.
+---Example:
+---
+---```lua
+---sidebar_titles = {
+---  ["aerial"] = "Symbols",
+---  ["neo-tree"] = "Explorer",
+---}
+---```
+---@field sidebar_titles table<string,string[]>?
 ---**MEANT FOR INTERNAL USE ONLY**
 ---Conversion table of vim mode text to readable text and color name to be used
 ---Example:
@@ -193,6 +203,7 @@ local M = {
     colors = {},
     fallback_colors = {},
     icon_highlights = {},
+    sidebar_titles = {},
     modes = {},
     separators = {},
     setup_colors = nil,

--- a/lua/astroui/status/component.lua
+++ b/lua/astroui/status/component.lua
@@ -56,6 +56,31 @@ function M.file_info(opts)
   }))
 end
 
+--- A function to build a component for automatic sidebar padding with a title.
+---@param opts? table options for configuring builder settings
+---@return table # The Heirline component table
+function M.sidebar_title(opts)
+  opts = extend_tbl({
+    condition = function(self)
+      self.winid = vim.api.nvim_tabpage_list_wins(0)[1]
+      self.winwidth = vim.api.nvim_win_get_width(self.winid)
+      self.bufnr = vim.api.nvim_win_get_buf(self.winid)
+      return self.winwidth ~= vim.o.columns -- only apply to sidebars
+        and not buf_utils.is_valid(self.bufnr) -- if buffer is not in tabline
+    end,
+    provider = function(self)
+      local ft = vim.bo[self.bufnr].filetype
+      local title = config.sidebar_titles and config.sidebar_titles[ft] or ft
+      local padding = self.winwidth + 1 - #title
+      local left = padding / 2
+      return (" "):rep(left) .. title .. (" "):rep(padding - left)
+    end,
+    update = { "WinNew", "WinEnter", "WinResized" },
+    hl = hl.get_attributes("sidebar_title", true),
+  }, opts)
+  return M.builder(opts)
+end
+
 --- A function with different file_info defaults specifically for use in the tabline
 ---@param opts? table options for configuring file_icon, filename, filetype, file_modified, file_read_only, and the overall padding
 ---@return table # The Heirline component table


### PR DESCRIPTION
## 📑 Description

Add a component to display sidebar titles.

With NeoTree opened:

![Screenshot from 2024-04-29 13-38-32](https://github.com/AstroNvim/astroui/assets/73006950/48ef6f5b-6eb9-43ca-b737-977497d9a4cd)

With Aerial opened:

![Screenshot from 2024-04-29 13-37-50](https://github.com/AstroNvim/astroui/assets/73006950/df5d702d-230d-4b50-8999-f13213a6c3f6)

The original code is taken from: [AstroNvim/AstroNvim/lua/astronvim/plugins/heirline.lua](https://github.com/AstroNvim/AstroNvim/blob/f07ed64/lua/astronvim/plugins/heirline.lua#L89-L98)
