### PR TITLE
Relativize path in separated_path to home

### DIFF
--- a/lua/astroui/status/init.lua
+++ b/lua/astroui/status/init.lua
@@ -95,6 +95,7 @@ function M.separated_path(opts)
   if opts.suffix == true then opts.suffix = opts.separator end
   return function(self)
     local path = opts.path_func(self)
+    path = vim.fn.fnamemodify(path, ":~")
     if path == "." then path = "" end -- if there is no path, just replace with empty string
     local data = vim.fn.split(path, opts.delimiter)
     local children = {}


### PR DESCRIPTION
<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below
Closes #<Issue # here>
-->

## 📑 Description

It's very common to see $HOME as ~, to the point of it being weird when it's _not_ presented as ~

So, this PR makes `separated_path` display the $HOME part of the path as ~, if possible.

<!-- Add a brief description of the pr -->

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ℹ Additional Information

<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
