### PR TITLE
feat: add padding when icon not exists

### DIFF
--- a/lua/astroui/status/component.lua
+++ b/lua/astroui/status/component.lua
@@ -37,8 +37,8 @@ end
 -- @usage local heirline_component = require("astroui.status").component.file_info()
 function M.file_info(opts)
   opts = extend_tbl({
-    file_icon = { hl = hl.file_icon "statusline", padding = { left = 1, right = 1 }, condition = condition.is_file },
-    filename = false,
+    file_icon = { hl = hl.file_icon "statusline", padding = { left = 1 }, condition = condition.is_file },
+    filename = padding = { left = 1 },
     filetype = {},
     file_modified = { padding = { left = 1 }, condition = condition.is_file },
     file_read_only = { padding = { left = 1 }, condition = condition.is_file },


### PR DESCRIPTION
<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below
Closes #<Issue # here>
-->

## 📑 Description
add padding when icon not exists

before:
![image](https://github.com/AstroNvim/astroui/assets/51357674/b6ee5eea-3142-442e-98b7-2ee5ffcf1c82)

after:
![image](https://github.com/AstroNvim/astroui/assets/51357674/2e1e403f-89b2-4342-b3c6-bc3eb253fd56)

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ℹ Additional Information

<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
