### PR TITLE
fix(heirline): fix some icons not being correctly highlighted

### DIFF
--- a/lua/astroui/status/heirline.lua
+++ b/lua/astroui/status/heirline.lua
@@ -30,11 +30,21 @@ function M.tab_type(self, prefix)
   return (prefix or "buffer") .. tab_type
 end
 
+local function cached_func(func, ...)
+  local cached
+  local args = { ... }
+  return function(self)
+    if cached == nil then cached = func(unpack(args)) end
+    if type(cached) == "function" then return cached(self) end
+    return cached
+  end
+end
+
 --- Make a list of buffers, rendering each buffer with the provided component
 ---@param component table
 ---@return table
 function M.make_buflist(component)
-  local overflow_hl = hl.get_attributes("buffer_overflow", true)
+  local overflow_hl = cached_func(hl.get_attributes, "buffer_overflow", true)
   return require("heirline.utils").make_buflist(
     status_utils.surround(
       "tab",
@@ -70,7 +80,7 @@ function M.make_buflist(component)
             end
           end,
           provider = function(self) return provider.str { str = self.label, padding = { left = 1, right = 1 } } end,
-          hl = hl.get_attributes "buffer_picker",
+          hl = cached_func(hl.get_attributes, "buffer_picker"),
         },
         component, -- create buffer component
       },


### PR DESCRIPTION
## 📑 Description

Fix some heirline icons (buffer picker key and buffer list overflow back arrow) not being correctly highlighted. This is the same issue as https://github.com/AstroNvim/AstroNvim/pull/2815, as the `make_buflist()` function gets called during heirline's `opts` function, so i used the same solution as was used there with the `cached_func()` function

Since this might be a common pattern for using the `hl.get_attributes()` function, perhaps it would make sense to include `cached_func()` in the utils module? There are a bunch of `hl.get_attributes()` calls with constant arguments manually wrapped in functions in the `status.config` module that might benefit as well from this