### PR TITLE
fix(lazygit): only write palette escapes when stdout is a terminal

### DIFF
--- a/lua/astroui/lazygit.lua
+++ b/lua/astroui/lazygit.lua
@@ -5,10 +5,18 @@ local M = {}
 local astroui = require "astroui"
 local config = astroui.config.lazygit
 
---- Whether Neovim's stdout is a terminal that can receive escape sequences.
---- With a GUI frontend (Neovide, neovim-qt, any `--embed` client) stdout is the
---- msgpack-RPC channel instead, so writing to it corrupts the protocol stream.
-local function stdout_is_tty() return vim.uv.guess_handle(1) == "tty" end
+--- Whether the builtin TUI is attached to a terminal that can receive escape
+--- sequences, checked at call time since UIs can attach and detach over a
+--- session. This is the same check Neovim core uses before emitting escape
+--- sequences (`runtime/lua/vim/_defaults.lua`). With a GUI frontend (Neovide,
+--- neovim-qt, any `--embed` client) stdout is the msgpack-RPC channel instead,
+--- so writing to it corrupts the protocol stream.
+local function tui_attached()
+  for _, ui in ipairs(vim.api.nvim_list_uis()) do
+    if ui.chan == 1 and ui.stdout_tty then return true end
+  end
+  return false
+end
 
 -- Build theme configuration file
 function M.update_config()
@@ -29,7 +37,11 @@ function M.update_config()
     end
     if type(k) == "number" then
       -- numeric keys set terminal palette entries, which only a terminal can act on
-      if stdout_is_tty() then pcall(io.write, ("\27]4;%d;%s\7"):format(k, color[1])) end
+      if vim.api.nvim_ui_send then -- Neovim 0.12+: routed to the TUI host terminal, no-op for GUIs
+        pcall(vim.api.nvim_ui_send, ("\27]4;%d;%s\7"):format(k, color[1]))
+      elseif tui_attached() then
+        pcall(io.write, ("\27]4;%d;%s\7"):format(k, color[1]))
+      end
     else
       theme[k] = color
     end

--- a/lua/astroui/lazygit.lua
+++ b/lua/astroui/lazygit.lua
@@ -5,6 +5,11 @@ local M = {}
 local astroui = require "astroui"
 local config = astroui.config.lazygit
 
+--- Whether Neovim's stdout is a terminal that can receive escape sequences.
+--- With a GUI frontend (Neovide, neovim-qt, any `--embed` client) stdout is the
+--- msgpack-RPC channel instead, so writing to it corrupts the protocol stream.
+local function stdout_is_tty() return vim.uv.guess_handle(1) == "tty" end
+
 -- Build theme configuration file
 function M.update_config()
   if not config then return end
@@ -23,7 +28,8 @@ function M.update_config()
       if v[modifier] then table.insert(color, modifier) end
     end
     if type(k) == "number" then
-      pcall(io.write, ("\27]4;%d;%s\7"):format(k, color[1]))
+      -- numeric keys set terminal palette entries, which only a terminal can act on
+      if stdout_is_tty() then pcall(io.write, ("\27]4;%d;%s\7"):format(k, color[1])) end
     else
       theme[k] = color
     end

--- a/lua/astroui/lazygit.lua
+++ b/lua/astroui/lazygit.lua
@@ -5,24 +5,21 @@ local M = {}
 local astroui = require "astroui"
 local config = astroui.config.lazygit
 
---- Whether the builtin TUI is attached to a terminal that can receive escape
---- sequences, checked at call time since UIs can attach and detach over a
---- session. This is the same check Neovim core uses before emitting escape
---- sequences (`runtime/lua/vim/_defaults.lua`). With a GUI frontend (Neovide,
---- neovim-qt, any `--embed` client) stdout is the msgpack-RPC channel instead,
---- so writing to it corrupts the protocol stream.
-local function tui_attached()
-  for _, ui in ipairs(vim.api.nvim_list_uis()) do
-    if ui.chan == 1 and ui.stdout_tty then return true end
-  end
-  return false
-end
-
 -- Build theme configuration file
 function M.update_config()
   if not config then return end
   ---@type table<string, string[]>
   local theme = {}
+
+  -- Check if TUI is attached
+  -- TODO: REMOVE WHEN DROPPING SUPPORT FOR NEOVIM v0.11
+  local tui_attached = false
+  for _, ui in ipairs(vim.api.nvim_list_uis()) do
+    if ui.chan == 1 and ui.stdout_tty then
+      tui_attached = true
+      break
+    end
+  end
 
   for k, v in pairs(config.theme or {}) do
     local color = {}
@@ -37,11 +34,8 @@ function M.update_config()
     end
     if type(k) == "number" then
       -- numeric keys set terminal palette entries, which only a terminal can act on
-      if vim.api.nvim_ui_send then -- Neovim 0.12+: routed to the TUI host terminal, no-op for GUIs
-        pcall(vim.api.nvim_ui_send, ("\27]4;%d;%s\7"):format(k, color[1]))
-      elseif tui_attached() then
-        pcall(io.write, ("\27]4;%d;%s\7"):format(k, color[1]))
-      end
+      -- TODO: REMOVE io.write WHEN DROPPING SUPPORT FOR NEOVIM v0.11
+      if tui_attached then pcall(vim.api.nvim_ui_send or io.write, ("\27]4;%d;%s\7"):format(k, color[1])) end
     else
       theme[k] = color
     end


### PR DESCRIPTION
### Problem

Numeric keys in the lazygit theme (AstroNvim ships `[241] = { fg = "Special" }`) are applied by writing an OSC 4 escape straight to Neovim's stdout:

https://github.com/AstroNvim/astroui/blob/main/lua/astroui/lazygit.lua#L26

That is meaningful only when Neovim owns a tty. Under a GUI frontend, stdout is the msgpack-RPC channel to the client, so the escape bytes are injected into the protocol stream.

Because `require("astroui.lazygit").setup()` runs from `astroui/init.lua`, this fires on startup and again on every colorscheme change — regardless of whether the user ever opens lazygit. On Neovide every one of them produces:

```
ERROR [neovide::bridge::session] ^[]4;241;#f5c2e8^G
```

Neovide discards the unparseable bytes and recovers, so the practical impact is log noise rather than a broken session, but writing arbitrary bytes into a msgpack stream isn't something to rely on.

The existing `pcall` can't help here: the write *succeeds*, it just arrives somewhere it shouldn't.

### Fix

Guard the write on stdout actually being a terminal:

```lua
vim.uv.guess_handle(1) == "tty"
```

Measured on Neovim 0.11 / Neovide 0.16.2:

| Frontend | `guess_handle(1)` | writes escape |
| --- | --- | --- |
| kitty (terminal) | `tty` | yes (as before) |
| Neovide | `pipe` | no (was the bug) |
| `--headless`, stdout redirected | `file` | no (never reached a terminal anyway) |

Terminal behaviour is unchanged, and the generated lazygit theme YAML — the named keys — is untouched in all cases.

### Notes

- `vim.uv` needs Neovim >= 0.10, which is below this repo's floor since 1e36aa9.
- folke/snacks.nvim carries the same line, which this file was adapted from ([`lua/snacks/lazygit.lua#L153`](https://github.com/folke/snacks.nvim/blob/main/lua/snacks/lazygit.lua#L153)). There it only runs when the user actually opens lazygit, so the exposure is much smaller. Happy to report it there separately.

### Testing

Repro on Neovide before the patch, silent after it, across 3 runs each:

```
neovide --no-fork +qa
```

`stylua --check` and `selene` are clean on the changed file and on `lua/` as a whole.
