### PR TITLE
fix(status): refresh lazy providers and environment visibility

### DIFF
--- a/lua/astroui/status/component.lua
+++ b/lua/astroui/status/component.lua
@@ -14,6 +14,7 @@ local extend_tbl = astro.extend_tbl
 
 local ui = require "astroui"
 local config = assert(ui.config.status)
+local condition = require "astroui.status.condition"
 local init = require "astroui.status.init"
 local provider = require "astroui.status.provider"
 local status_utils = require "astroui.status.utils"
@@ -179,6 +180,14 @@ end
 -- @usage local heirline_component = require("astroui.status").component.git_branch()
 function M.virtual_env(opts)
   opts = extend_tbl(vim.tbl_get(config, "components", "virtual_env"), opts)
+  if opts.surround and opts.surround.condition == nil then
+    opts.surround = vim.tbl_extend("force", {}, opts.surround)
+    local virtual_env_opts = opts.virtual_env
+      and extend_tbl(vim.tbl_get(config, "providers", "virtual_env"), opts.virtual_env)
+    opts.surround.condition = function()
+      return virtual_env_opts and condition.has_virtual_env(virtual_env_opts.conda) or false
+    end
+  end
   return M.builder(status_utils.setup_providers(opts, { "virtual_env" }))
 end
 

--- a/lua/astroui/status/condition.lua
+++ b/lua/astroui/status/condition.lua
@@ -158,9 +158,16 @@ function M.is_file(bufnr)
 end
 
 --- A condition function if a virtual environment is activated
+---@param conda? { enabled: boolean?, ignore_base: boolean? } Conda environment display options
 ---@return boolean # whether or not virtual environment is activated
 -- @usage local heirline_component = { provider = "Example Provider", condition = require("astroui.status").condition.has_virtual_env }
-function M.has_virtual_env() return vim.env.VIRTUAL_ENV ~= nil or vim.env.CONDA_DEFAULT_ENV ~= nil end
+function M.has_virtual_env(conda)
+  local venv = vim.env.VIRTUAL_ENV
+  if venv and venv ~= "" then return true end
+  local conda_env = vim.env.CONDA_DEFAULT_ENV
+  if not conda_env or conda_env == "" then return false end
+  return not conda or (conda.enabled ~= false and (conda_env ~= "base" or not conda.ignore_base))
+end
 
 --- A condition function if Aerial is available
 ---@return boolean # whether or not aerial plugin is installed

--- a/lua/astroui/status/config.lua
+++ b/lua/astroui/status/config.lua
@@ -646,7 +646,6 @@ return {
       surround = {
         separator = "right",
         color = "virtual_env_bg",
-        condition = function() return require("astroui.status.condition").has_virtual_env() end,
       },
       hl = function() return require("astroui.status.hl").get_attributes "virtual_env" end,
       on_click = {

--- a/lua/astroui/status/provider.lua
+++ b/lua/astroui/status/provider.lua
@@ -577,11 +577,11 @@ function M.virtual_env(opts)
     local conda = vim.env.CONDA_DEFAULT_ENV
     local venv = vim.env.VIRTUAL_ENV
     local env_str
-    if venv then
+    if venv and venv ~= "" then
       local path = vim.fn.split(venv, "/")
       env_str = path[#path]
       if #path > 1 and vim.tbl_contains(opts.env_names, env_str) then env_str = path[#path - 1] end
-    elseif opts.conda.enabled and conda then
+    elseif opts.conda.enabled and conda and conda ~= "" then
       if conda ~= "base" or not opts.conda.ignore_base then env_str = conda end
     end
     if env_str and opts.format then

--- a/lua/astroui/status/utils.lua
+++ b/lua/astroui/status/utils.lua
@@ -138,7 +138,7 @@ function M.surround(separator, color, component, condition, update)
   return surrounded
 end
 
----@type false|fun(bufname: string, filetype: string, buftype: string): string?,string?
+---@type false|nil|fun(bufname: string, filetype: string, buftype: string): string?,string?
 local cached_icon_provider
 --- Resolve the icon and color information for a given buffer
 ---@param bufnr integer the buffer number to resolve the icon and color of
@@ -150,7 +150,10 @@ function M.icon_provider(bufnr)
   local filetype = vim.bo[bufnr].filetype
   local buftype = vim.bo[bufnr].buftype
   if cached_icon_provider then return cached_icon_provider(bufname, filetype, buftype) end
-  if cached_icon_provider == false then return end
+  if cached_icon_provider == false then
+    if not _G.MiniIcons and not package.loaded["nvim-web-devicons"] then return end
+    cached_icon_provider = nil
+  end
 
   local _, mini_icons = pcall(require, "mini.icons")
   -- mini.icons


### PR DESCRIPTION
**Icon providers**

- Recheck the cached no-provider state when MiniIcons or nvim-web-devicons loads later.
- Preserve the fast no-provider path until a supported provider becomes available.

**Virtual environments**

- Use matching visibility rules in the surround condition and rendered provider.
- Treat empty environment variables as absent and allow a named Conda environment to remain visible.
- Honor global and component-local Conda options, including `ignore_base = false`.
- Preserve custom surround conditions and explicit `condition = false`.

**Validation**

- Passed StyLua, Selene, typos, Lua compilation, and diff checks.
- Passed focused icon-provider and virtual-environment regressions on Neovim 0.11.0 and 0.12.4.
